### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,13 +135,13 @@
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 
-                <%# 商品が売れていればsold outを表示しましょう %>
+                <%# 商品購入機能実装後に商品が売れていればsold outを表示する設定予定 %>
                 <%#<% if @item.buys.present? %>
                   <div class='sold-out'>
                     <span>Sold Out!!</span>
                   </div>
                 <%#<% end %>
-                <%# //商品が売れていればsold outを表示しましょう %>
+                <%# //商品購入機能実装後に商品が売れていればsold outを表示する設定予定 %>
 
               </div>
               <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -112,9 +112,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,78 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%#<% if @item.buys.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <%#<% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.post_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+
+    <% else %>
 
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <% if user_signed_in? %>
+        <%#<% unless @item.buys.present? %>
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%#<% end %>
+      <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.post_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.sender.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.ship_date.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,24 +26,17 @@
     </div>
 
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-    <% else %>
-
-
-      <%# 商品購入機能実装後に、商品が売れていない場合はこちらを表示させるという設定を入れる予定 %>
-      <% if user_signed_in? %>
-        <%#<% unless @item.buys.present? %>
-          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <%#<% end %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
+        <%# 商品購入機能実装後に、商品が売れていない場合はこちらを表示させるという設定を入れる予定 %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品購入機能実装後に、商品が売れていない場合はこちらを表示させるという設定を入れる予定 %>
       <% end %>
-      <%# //商品購入機能実装後に、商品が売れていない場合はこちらを表示させるという設定を入れる予定 %>
     <% end %>
-
 
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,7 +10,7 @@
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品購入機能実装後に商品が売れている場合は、sold outを表示する設定予定 %>
       <%#<% if @item.buys.present? %>
-        <%#<div class="sold-out">
+        <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
       <%#<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,13 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# 商品購入機能実装後に商品が売れている場合は、sold outを表示する設定予定 %>
       <%#<% if @item.buys.present? %>
-        <div class="sold-out">
+        <%#<div class="sold-out">
           <span>Sold Out!!</span>
         </div>
       <%#<% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# //商品購入機能実装後に商品が売れている場合は、sold outを表示する設定予定 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -25,7 +25,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
 
@@ -36,17 +35,16 @@
     <% else %>
 
 
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%# 商品購入機能実装後に、商品が売れていない場合はこちらを表示させるという設定を入れる予定 %>
       <% if user_signed_in? %>
         <%#<% unless @item.buys.present? %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
         <%#<% end %>
       <% end %>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <%# //商品購入機能実装後に、商品が売れていない場合はこちらを表示させるという設定を入れる予定 %>
     <% end %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -115,7 +113,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
#What
標品詳細ページの表示

#Why
購入する際や、出品状況を確認するときなどに商品の詳しい内容や、購入手続きへ移行するためのもの。

#画像
ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/b6aed850b72502b5768e025057a54a86.gif)](https://gyazo.com/b6aed850b72502b5768e025057a54a86)

 ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/28eca9162cb1f5a2309a0e4cdc3eb1c7.gif)](https://gyazo.com/28eca9162cb1f5a2309a0e4cdc3eb1c7)

 ログアウト状態で、商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/7e16276389dae49a32a966d94f3bb125.gif)](https://gyazo.com/7e16276389dae49a32a966d94f3bb125)